### PR TITLE
Stop scheduler when done

### DIFF
--- a/lib/vessel/engine.rb
+++ b/lib/vessel/engine.rb
@@ -30,6 +30,9 @@ module Vessel
 
         @queue.close if idle?
       end
+
+    ensure
+      scheduler.stop
     end
 
     def handle(page, args)

--- a/lib/vessel/engine.rb
+++ b/lib/vessel/engine.rb
@@ -45,6 +45,8 @@ module Vessel
       page.close if page
     end
 
+    private
+
     def start_requests
       Request.build(*settings[:start_urls])
     end

--- a/lib/vessel/scheduler.rb
+++ b/lib/vessel/scheduler.rb
@@ -6,7 +6,7 @@ require "concurrent-ruby"
 module Vessel
   class Scheduler
     extend Forwardable
-    delegate %i[scheduled_task_count completed_task_count queue_length] => :@pool
+    delegate %i[scheduled_task_count completed_task_count queue_length] => :pool
 
     attr_reader :browser, :queue, :delay
 

--- a/lib/vessel/scheduler.rb
+++ b/lib/vessel/scheduler.rb
@@ -33,6 +33,12 @@ module Vessel
       end
     end
 
+    def stop
+      pool.shutdown
+      pool.kill unless pool.wait_for_termination(30)
+      browser.quit
+    end
+
     private
 
     def pool

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Vessel::Engine do
+	let(:crawler_class)  { Class.new(Vessel::Cargo) }
+	let(:handler)        { Proc.new {} }
+	let(:engine)         { described_class.new(crawler_class, &handler) }
+
+	describe '.new' do
+		it { expect( engine.crawler_class ).to be(crawler_class) }
+		it { expect( engine.settings      ).to be(crawler_class.settings) }
+		it { expect( engine.middleware    ).to be(handler) }
+		it { expect( engine.scheduler     ).to be_a(Vessel::Scheduler) }
+	end
+
+	describe '#run' do
+		let(:page)     { double(Ferrum::Page) }
+		let(:request)  { Vessel::Request.new }
+
+		before do
+			# stub out scheduler
+			allow( engine.scheduler ).to receive(:post)
+			# stub out handle call (tested below)
+			allow( engine ).to receive(:handle)
+			# put something in the queue
+			engine.scheduler.queue << [page, request]
+		end
+
+		it 'posts start requests' do
+			engine.run
+
+			expect( engine.scheduler ).to have_received(:post).with(
+				instance_of(Vessel::Request)
+			)
+		end
+
+		it 'processes queue until empty' do
+			expect { engine.run }.to change( engine.scheduler.queue, :length ).from(1).to(0)
+		end
+
+		it 'handles pages found in queue' do
+			engine.run
+
+			expect( engine ).to have_received(:handle).with(page, [request.method])
+		end
+
+		it 're-raises exception found in queue' do
+			engine.scheduler.queue << (error = StandardError.new)
+
+			expect { engine.run }.to raise_error(error)
+		end
+	end
+
+	describe '#handle' do
+		let(:crawler) { crawler_class.new(page) }
+		let(:page)    { double(Ferrum::Page) }
+		let(:result)  { double('Crawler#parse result') }
+		let(:request) { Vessel::Request.new }
+
+		before do
+			allow(crawler_class).to receive(:new).and_return(crawler)
+			allow(crawler).to receive(:parse).and_yield(request).and_yield(result)
+			allow(engine.middleware).to receive(:call)
+			allow(engine.scheduler).to receive(:post)
+			allow(page).to receive(:close)
+
+			engine.handle(page, [:parse])
+		end
+
+		it 'creates a new crawler instance and calls #parse to process the page' do
+			expect( crawler_class ).to have_received(:new).with(page)
+			expect( crawler ).to have_received(:parse)
+		end
+
+		it 'calls block handler or middleware with #parse results' do
+			expect( engine.middleware ).to have_received(:call).with(result)
+		end
+
+		it 'schedules new requests emitted by #parse' do
+			expect( engine.scheduler ).to have_received(:post).with(request)
+		end
+
+		it 'closes the page when done' do
+			expect( page ).to have_received(:close)
+		end
+	end
+
+end

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -3,87 +3,100 @@
 require "spec_helper"
 
 describe Vessel::Engine do
-	let(:crawler_class)  { Class.new(Vessel::Cargo) }
-	let(:handler)        { Proc.new {} }
-	let(:engine)         { described_class.new(crawler_class, &handler) }
+  let(:crawler_class)  { Class.new(Vessel::Cargo) }
+  let(:handler)        { Proc.new {} }
+  let(:engine)         { described_class.new(crawler_class, &handler) }
 
-	describe '.new' do
-		it { expect( engine.crawler_class ).to be(crawler_class) }
-		it { expect( engine.settings      ).to be(crawler_class.settings) }
-		it { expect( engine.middleware    ).to be(handler) }
-		it { expect( engine.scheduler     ).to be_a(Vessel::Scheduler) }
-	end
+  describe '.new' do
+    it { expect( engine.crawler_class ).to be(crawler_class) }
+    it { expect( engine.settings      ).to be(crawler_class.settings) }
+    it { expect( engine.middleware    ).to be(handler) }
+    it { expect( engine.scheduler     ).to be_a(Vessel::Scheduler) }
+  end
 
-	describe '#run' do
-		let(:page)     { double(Ferrum::Page) }
-		let(:request)  { Vessel::Request.new }
+  describe '#run' do
+    let(:page)     { double(Ferrum::Page) }
+    let(:request)  { Vessel::Request.new }
 
-		before do
-			# stub out scheduler
-			allow( engine.scheduler ).to receive(:post)
-			# stub out handle call (tested below)
-			allow( engine ).to receive(:handle)
-			# put something in the queue
-			engine.scheduler.queue << [page, request]
-		end
+    before do
+      # stub out scheduler
+      allow( engine.scheduler ).to receive(:post)
+      allow( engine.scheduler ).to receive(:stop)
+      # stub out handle call (tested below)
+      allow( engine ).to receive(:handle)
+      # put something in the queue
+      engine.scheduler.queue << [page, request]
+    end
 
-		it 'posts start requests' do
-			engine.run
+    it 'posts start requests' do
+      engine.run
 
-			expect( engine.scheduler ).to have_received(:post).with(
-				instance_of(Vessel::Request)
-			)
-		end
+      expect( engine.scheduler ).to have_received(:post).with(
+        instance_of(Vessel::Request)
+      )
+    end
 
-		it 'processes queue until empty' do
-			expect { engine.run }.to change( engine.scheduler.queue, :length ).from(1).to(0)
-		end
+    it 'processes queue until empty' do
+      expect { engine.run }.to change( engine.scheduler.queue, :length ).from(1).to(0)
+    end
 
-		it 'handles pages found in queue' do
-			engine.run
+    it 'handles pages found in queue' do
+      engine.run
 
-			expect( engine ).to have_received(:handle).with(page, [request.method])
-		end
+      expect( engine ).to have_received(:handle).with(page, [request.method])
+    end
 
-		it 're-raises exception found in queue' do
-			engine.scheduler.queue << (error = StandardError.new)
+    it 'stops the scheduler when done' do
+      engine.run
 
-			expect { engine.run }.to raise_error(error)
-		end
-	end
+      expect( engine.scheduler ).to have_received(:stop)
+    end
 
-	describe '#handle' do
-		let(:crawler) { crawler_class.new(page) }
-		let(:page)    { double(Ferrum::Page) }
-		let(:result)  { double('Crawler#parse result') }
-		let(:request) { Vessel::Request.new }
+    it 're-raises exception found in queue' do
+      engine.scheduler.queue << (error = StandardError.new)
 
-		before do
-			allow(crawler_class).to receive(:new).and_return(crawler)
-			allow(crawler).to receive(:parse).and_yield(request).and_yield(result)
-			allow(engine.middleware).to receive(:call)
-			allow(engine.scheduler).to receive(:post)
-			allow(page).to receive(:close)
+      expect { engine.run }.to raise_error(error)
+    end
 
-			engine.handle(page, [:parse])
-		end
+    it 'ensures the scheduler is stopped' do
+      engine.scheduler.queue << (error = StandardError.new)
+      expect { engine.run }.to raise_error(error)
+      expect( engine.scheduler ).to have_received(:stop)
+    end
+  end
 
-		it 'creates a new crawler instance and calls #parse to process the page' do
-			expect( crawler_class ).to have_received(:new).with(page)
-			expect( crawler ).to have_received(:parse)
-		end
+  describe '#handle' do
+    let(:crawler) { crawler_class.new(page) }
+    let(:page)    { double(Ferrum::Page) }
+    let(:result)  { double('Crawler#parse result') }
+    let(:request) { Vessel::Request.new }
 
-		it 'calls block handler or middleware with #parse results' do
-			expect( engine.middleware ).to have_received(:call).with(result)
-		end
+    before do
+      allow(crawler_class).to receive(:new).and_return(crawler)
+      allow(crawler).to receive(:parse).and_yield(request).and_yield(result)
+      allow(engine.middleware).to receive(:call)
+      allow(engine.scheduler).to receive(:post)
+      allow(page).to receive(:close)
 
-		it 'schedules new requests emitted by #parse' do
-			expect( engine.scheduler ).to have_received(:post).with(request)
-		end
+      engine.handle(page, [:parse])
+    end
 
-		it 'closes the page when done' do
-			expect( page ).to have_received(:close)
-		end
-	end
+    it 'creates a new crawler instance and calls #parse to process the page' do
+      expect( crawler_class ).to have_received(:new).with(page)
+      expect( crawler ).to have_received(:parse)
+    end
+
+    it 'calls block handler or middleware with #parse results' do
+      expect( engine.middleware ).to have_received(:call).with(result)
+    end
+
+    it 'schedules new requests emitted by #parse' do
+      expect( engine.scheduler ).to have_received(:post).with(request)
+    end
+
+    it 'closes the page when done' do
+      expect( page ).to have_received(:close)
+    end
+  end
 
 end

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -16,6 +16,12 @@ module Vessel
       expect( scheduler.browser ).to be_a(Ferrum::Browser)
     end
 
+    it 'has thread pool statistics' do
+      expect( scheduler.scheduled_task_count ).to eq(0)
+      expect( scheduler.completed_task_count ).to eq(0)
+      expect( scheduler.queue_length ).to eq(0)
+    end
+
     describe '#post' do
       let(:request) { Vessel::Request.new } # empty request stub
 

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Vessel
+  describe Scheduler do
+    let(:settings)  { Vessel::Cargo.settings }
+    let(:queue)     { SizedQueue.new(settings[:max_threads]) }
+    let(:scheduler) { Scheduler.new(queue, settings) }
+
+    it 'has a queue' do
+      expect( scheduler.queue ).to be(queue)
+    end
+
+		it 'has a browser' do
+      expect( scheduler.browser ).to be_a(Ferrum::Browser)
+    end
+
+    describe '#post' do
+      let(:request) { Vessel::Request.new } # empty request stub
+
+      before { scheduler.post(request) }
+
+      it 'schedules requests for execution' do
+        expect( scheduler.queue.length ).to eq(0)
+
+        sleep 1 # wait for execution
+
+        expect( scheduler.queue.length ).to eq(1)
+        expect( scheduler.queue.pop ).to eq([nil, request])
+      end
+
+      it 'updates thread pool statistics' do
+        expect( scheduler.scheduled_task_count ).to eq(1)
+        expect( scheduler.completed_task_count ).to eq(0)
+
+        sleep 1 # wait for execution
+
+        expect( scheduler.scheduled_task_count ).to eq(1)
+        expect( scheduler.completed_task_count ).to eq(1)
+      end
+    end
+
+  end
+end

--- a/spec/scheduler_spec.rb
+++ b/spec/scheduler_spec.rb
@@ -47,5 +47,37 @@ module Vessel
       end
     end
 
+    describe '#stop' do
+      let(:browser) { spy('Ferrum::Browser') }
+      let(:pool) { spy('ThreadPoolExecutor') }
+
+      before do
+        scheduler.instance_variable_set(:@browser, browser)
+        scheduler.instance_variable_set(:@pool, pool)
+      end
+
+      it 'attempts to shut down the thread pool' do
+        scheduler.stop
+
+        expect( pool ).to have_received(:shutdown)
+        expect( pool ).not_to have_received(:kill)
+      end
+
+      it 'kills the thread pool if necessary' do
+        allow( pool ).to receive(:wait_for_termination).and_return(false)
+
+        scheduler.stop
+
+        expect( pool ).to have_received(:shutdown)
+        expect( pool ).to have_received(:kill)
+      end
+
+      it 'quits the browser' do
+        scheduler.stop
+
+        expect( scheduler.browser ).to have_receive(:quit)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
## Summary

Adds a new method, `Scheduler#stop`, to orderly shut down the thread pool which otherwise may continue running in the background even after the crawler has finished.

Ensures that `Scheduler#stop` is called when `Engine#run` is finished.

## Details

`Scheduler#stop` will shut down the thread pool using the recommended procedure in the [relevant documentation](http://ruby-concurrency.github.io/concurrent-ruby/1.1.6/Concurrent/ThreadPoolExecutor.html). It will wait for up to 30 seconds for the pool to shut down normally, and then kill it.

It also calls `#quit` on its `Ferrum::Browser` instance to allow the headless browser instance to close.

### Included Tests

Includes specs for added functionality, as well as adding specs for existing functionality in `Scheduler` and `Engine`. Can submit the latter as a separate PR if desired.

This resolves #4.