### PR TITLE
Fix driver start

### DIFF
--- a/lib/vessel/driver.rb
+++ b/lib/vessel/driver.rb
@@ -23,7 +23,7 @@ module Vessel
 
     def initialize(settings = nil)
       @settings = settings
-      start(settings[:driver_options])
+      start(**settings[:driver_options])
       at_exit { stop }
     end
 


### PR DESCRIPTION
It seems that `Vessel::Driver#initialize` is not calling `#start` properly.
Ruby version is 3.0.2.

## Sample
```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gem 'vessel', github: 'rubycdp/vessel'
end

class ExampleCom < Vessel::Cargo
  start_urls 'https://example.com/'

  def parse
    puts page.at_css('h1').text
  end
end

ExampleCom.run
```

## Result

```bash
/Users/milk1000cc/dev/vessel_sample/vendor/bundle/ruby/3.0.0/bundler/gems/vessel-99e042c5bd91/lib/vessel/driver/ferrum/driver.rb:20:in `start': wrong number of arguments (given 1, expected 0) (ArgumentError)
        from /Users/milk1000cc/dev/vessel_sample/vendor/bundle/ruby/3.0.0/bundler/gems/vessel-99e042c5bd91/lib/vessel/driver.rb:26:in `initialize'
        from /Users/milk1000cc/dev/vessel_sample/vendor/bundle/ruby/3.0.0/bundler/gems/vessel-99e042c5bd91/lib/vessel/driver.rb:15:in `new'
        from /Users/milk1000cc/dev/vessel_sample/vendor/bundle/ruby/3.0.0/bundler/gems/vessel-99e042c5bd91/lib/vessel/driver.rb:15:in `build'
        from /Users/milk1000cc/dev/vessel_sample/vendor/bundle/ruby/3.0.0/bundler/gems/vessel-99e042c5bd91/lib/vessel/scheduler.rb:18:in `initialize'
        from /Users/milk1000cc/dev/vessel_sample/vendor/bundle/ruby/3.0.0/bundler/gems/vessel-99e042c5bd91/lib/vessel/engine.rb:16:in `new'
        from /Users/milk1000cc/dev/vessel_sample/vendor/bundle/ruby/3.0.0/bundler/gems/vessel-99e042c5bd91/lib/vessel/engine.rb:16:in `initialize'
        from /Users/milk1000cc/dev/vessel_sample/vendor/bundle/ruby/3.0.0/bundler/gems/vessel-99e042c5bd91/lib/vessel/engine.rb:6:in `new'
        from /Users/milk1000cc/dev/vessel_sample/vendor/bundle/ruby/3.0.0/bundler/gems/vessel-99e042c5bd91/lib/vessel/engine.rb:6:in `run'
        from /Users/milk1000cc/dev/vessel_sample/vendor/bundle/ruby/3.0.0/bundler/gems/vessel-99e042c5bd91/lib/vessel/cargo.rb:16:in `run'
        from scrape.rb:16:in `<main>'
```