### PR TITLE
Inherit settings

### DIFF
--- a/lib/vessel/cargo.rb
+++ b/lib/vessel/cargo.rb
@@ -16,7 +16,7 @@ module Vessel
       Engine.run(self, &block)
     end
 
-    extend Settings
+    include Settings
     extend Forwardable
     delegate %i[at_css css at_xpath xpath] => :page
 

--- a/lib/vessel/cargo/settings.rb
+++ b/lib/vessel/cargo/settings.rb
@@ -1,57 +1,68 @@
 # frozen_string_literal: true
 
+require "active_support/concern"
+require "active_support/core_ext/class/attribute"
+
 module Vessel
   class Cargo
     module Settings
-      def domain(name)
-        settings[:domain] = name
+      extend ActiveSupport::Concern
+
+      included do
+        class_attribute :_settings, instance_writer: false, instance_reader: false
       end
 
-      def start_urls(*url_handlers)
-        settings[:start_urls] = url_handlers.compact.flatten.inject({}) do |options, url_handler|
-          options.merge(url_handler.is_a?(Hash) ? url_handler : { url_handler => Request::DEFAULT_HANDLER })
+      module ClassMethods
+        def domain(name)
+          settings[:domain] = name
         end
-      end
 
-      def driver(name, **options)
-        settings[:driver_name] = name.to_sym
-        settings[:driver_options] = options
-      end
+        def start_urls(*url_handlers)
+          settings[:start_urls] = url_handlers.compact.flatten.inject({}) do |options, url_handler|
+            options.merge(url_handler.is_a?(Hash) ? url_handler : { url_handler => Request::DEFAULT_HANDLER })
+          end
+        end
 
-      def delay(value)
-        settings[:delay] = value
-      end
+        def driver(name, **options)
+          settings[:driver_name] = name.to_sym
+          settings[:driver_options] = options
+        end
 
-      def headers(value)
-        settings[:headers] = value
-      end
+        def delay(value)
+          settings[:delay] = value
+        end
 
-      def threads(min: MIN_THREADS, max: MAX_THREADS)
-        settings[:min_threads] = min
-        settings[:max_threads] = max
-      end
+        def headers(value)
+          settings[:headers] = value
+        end
 
-      def middleware(*classes)
-        settings[:middleware] = classes
-      end
+        def threads(min: MIN_THREADS, max: MAX_THREADS)
+          settings[:min_threads] = min
+          settings[:max_threads] = max
+        end
 
-      # def proxy(callable)
-      #   settings[:proxy] = callable
-      # end
+        def middleware(*classes)
+          settings[:middleware] = classes
+        end
 
-      def settings
-        @settings ||= {
-          delay: DELAY,
-          start_urls: START_URLS,
-          middleware: MIDDLEWARE,
-          min_threads: MIN_THREADS,
-          max_threads: MAX_THREADS,
-          driver_name: :ferrum,
-          driver_options: {},
-          headers: nil,
-          # proxy: nil,
-          domain: name&.split("::")&.last&.downcase
-        }
+        # def proxy(callable)
+        #   settings[:proxy] = callable
+        # end
+
+        def settings
+          self._settings ||= {
+            delay: DELAY,
+            start_urls: START_URLS,
+            middleware: MIDDLEWARE,
+            min_threads: MIN_THREADS,
+            max_threads: MAX_THREADS,
+            driver_name: :ferrum,
+            driver_options: {},
+            headers: nil,
+            # proxy: nil,
+            domain: name&.split("::")&.last&.downcase
+          }
+        end
       end
     end
   end

--- a/lib/vessel/driver.rb
+++ b/lib/vessel/driver.rb
@@ -23,7 +23,7 @@ module Vessel
 
     def initialize(settings = nil)
       @settings = settings
-      start(settings[:driver_options])
+      start(**settings[:driver_options])
       at_exit { stop }
     end
 

--- a/vessel.gemspec
+++ b/vessel.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "ferrum", "~> 0.11"
   s.add_runtime_dependency "mechanize", ">= 2.8.2"
   s.add_runtime_dependency "thor", "~> 1.1"
+  s.add_runtime_dependency "activesupport", ">= 5.2"
 
   s.add_development_dependency "bundler", "~> 2.2"
   s.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
I want to inherit the settings of the parent class.

In the current master version, the following code will run in **headless** mode.

```ruby
class ApplicationSpider < Vessel::Cargo
  driver :ferrum, headless: false
end

class ExampleCom < ApplicationSpider
  start_urls 'https://example.com/'

  def parse
    puts page.at_css('h1').text
  end
end

ExampleCom.run
```