### PR TITLE
Deep clone settings

### DIFF
--- a/lib/vessel/cargo/settings.rb
+++ b/lib/vessel/cargo/settings.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 require "vessel/proxy"
+require "vessel/util"
 
 module Vessel
   class Cargo
     module Settings
+      include Vessel::Util
+
       DELAY = 0
       START_URLS = {}.freeze
       MIDDLEWARE = [].freeze
@@ -83,9 +86,7 @@ module Vessel
 
       def settings
         @settings ||= if superclass.respond_to?(:settings)
-                        clone = superclass.settings.dup
-                        clone[:cookies] = clone[:cookies].dup
-                        clone
+                        deep_clone(superclass.settings)
                       else
                         {
                           delay: DELAY, start_urls: START_URLS, middleware: MIDDLEWARE,

--- a/lib/vessel/request.rb
+++ b/lib/vessel/request.rb
@@ -1,9 +1,12 @@
 # frozen_string_literal: true
 
 require "addressable/uri"
+require "vessel/util"
 
 module Vessel
   class Request
+    include Vessel::Util
+
     DEFAULT_HANDLER = :parse
 
     attr_reader :url, :handler, :data, :delay, :cookies, :headers, :once
@@ -36,19 +39,6 @@ module Vessel
         cookies == other.cookies &&
         headers == other.headers &&
         once == other.once
-    end
-
-    private
-
-    def deep_clone(value)
-      case value
-      when Hash
-        value.inject({}) { |b, (k, v)| b.merge(k => deep_clone(v)) }
-      when Array
-        value.inject([]) { |b, v| b << deep_clone(v) }
-      else
-        value
-      end
     end
   end
 end

--- a/lib/vessel/util.rb
+++ b/lib/vessel/util.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Vessel
+  module Util
+    def deep_clone(value)
+      case value
+      when Hash
+        value.inject({}) { |b, (k, v)| b.merge(k => deep_clone(v)) }
+      when Array
+        value.inject([]) { |b, v| b << deep_clone(v) }
+      else
+        value
+      end
+    end
+  end
+end

--- a/spec/cargo_spec.rb
+++ b/spec/cargo_spec.rb
@@ -48,6 +48,25 @@ module Vessel
       end
     end
 
+    describe ".settings" do
+      it "copies settings to the subclasses" do
+        parent = Class.new(Vessel::Cargo) do
+          headers "Test" => "test"
+          cookies [
+            { name: "lang", value: "en", domain: "www.google.com", path: "/" }
+          ]
+        end
+        child = Class.new(parent)
+
+        expect(child.settings[:headers]).to eq(parent.settings[:headers])
+        expect(child.settings[:headers]).not_to equal(parent.settings[:headers])
+
+        expect(child.settings[:cookies]).to eq(parent.settings[:cookies])
+        expect(child.settings[:cookies]).not_to equal(parent.settings[:cookies])
+        expect(child.settings[:cookies][0]).not_to equal(parent.settings[:cookies][0])
+      end
+    end
+
     describe ".run" do
       it "merges with default settings" do
         allow(Engine).to receive(:run)


### PR DESCRIPTION
Settings in subclasses **reference** settings in the parent class.
I think this behavior is strange.

```ruby
class Parent < Vessel::Cargo
  headers "Test" => "test"
end

class Child < Parent
end

# This is good
p Child.settings[:headers] == { "Test" => "test" }

# I think this should be false
p Child.settings[:headers].object_id == Parent.settings[:headers].object_id
```