### PR TITLE
Vessel::Engine#run is never idle

### DIFF
--- a/lib/vessel/engine.rb
+++ b/lib/vessel/engine.rb
@@ -76,10 +76,10 @@ module Vessel
 
     def engine_idle?
       @queue.empty? &&
-        req_enqueued == res_dequeued &&
-        res_dequeued == res_handled &&
-        item_pipelined == item_processed &&
-        item_processed == (item_sent + item_rejected)
+        req_enqueued.value == res_dequeued.value &&
+        res_dequeued.value == res_handled.value &&
+        item_pipelined.value == item_processed.value &&
+        item_processed.value == (item_sent.value + item_rejected.value)
     end
 
     def engine_and_scheduler_idle?

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -15,15 +15,23 @@ describe Vessel::Engine do
   end
 
   describe "#run" do
-    let(:page)     { double(Ferrum::Page) }
-    let(:request)  { Vessel::Request.new }
+    let(:page)          { double(Ferrum::Page) }
+    let(:request)       { Vessel::Request.new }
+    let(:res_dequeued)  { double(Concurrent::AtomicFixnum, value: 0) }
+    let(:res_handled)  { double(Concurrent::AtomicFixnum, value: 0) }
 
     before do
       # stub out scheduler
       allow(engine.scheduler).to receive(:post)
       allow(engine.scheduler).to receive(:stop)
+      # stub out counters
+      allow(engine).to receive(:res_dequeued).and_return(res_dequeued)
+      allow(engine).to receive(:res_handled).and_return(res_handled)
       # stub out handle call (tested below)
-      allow(engine).to receive(:handle)
+      allow(engine).to receive(:handle) do
+        allow(res_dequeued).to receive(:value).and_return(1)
+        allow(res_handled).to receive(:value).and_return(1)
+      end
       # put something in the queue
       engine.scheduler.queue << [page, request]
     end


### PR DESCRIPTION
Since [the last commit](https://github.com/rubycdp/vessel/commit/5c2d2b29c0c684591b886b1ac6e1fa43fb98cbda), it seems `Vessel::Engine#run` is no longer completed correctly.
I fixed it.