### PR TITLE
Add Ruby 3.1 and 3.2 to CI.  Update checkout action version.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,14 +12,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [ 2.7, 3.0 ]
+        ruby-version: [ 2.7, '3.0', 3.1, 3.2 ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
+          bundler: latest
           bundler-cache: true
       - name: Run tests
         run: bundle exec rake


### PR DESCRIPTION
Had to set `bundler` to latest to ensure that Ruby 3.0 pulled a `bundler` compatible with the `~> 2.3` requirement.

Runs green on my fork.