### PR TITLE
Ensure the engine is idle even when multiple requests are scheduled at once

### DIFF
--- a/lib/vessel/engine.rb
+++ b/lib/vessel/engine.rb
@@ -93,7 +93,7 @@ module Vessel
     end
 
     def schedule(*requests)
-      requests.size.times { increase(:req_enqueued) }
+      requests.flatten.size.times { increase(:req_enqueued) }
       scheduler.post(*requests)
     end
 


### PR DESCRIPTION
If the crawler has multiple `start_urls` or yields multiple requests at once, the engine does not seem to terminate even if the process finishes successfully.

```ruby
class ExampleCrawler < Vessel::Cargo
  start_urls(
    "https://example.com/1" => :parse,
    "https://example.com/2" => :parse
  )

  def parse
    yield [
      request(url: "https://example.com/3", handler: :parse),
      request(url: "https://example.com/4", handler: :parse)
    ]
  end
end
```

The number of `req_enqueued` to be increased when scheduling seems to be wrong.