### PR TITLE
Support ferrum v0.15 with proxy

### DIFF
--- a/lib/vessel/driver/ferrum/driver.rb
+++ b/lib/vessel/driver/ferrum/driver.rb
@@ -35,7 +35,7 @@ module Vessel
           options = {}
           options.merge!(proxy: proxy) if proxy
           page = browser.create_page(**options)
-          Page.new(page)
+          Page.new(page, context: browser.contexts[page.context_id])
         end
       end
     end

--- a/lib/vessel/driver/ferrum/page.rb
+++ b/lib/vessel/driver/ferrum/page.rb
@@ -11,13 +11,14 @@ module Vessel
 
         attr_reader :page
 
-        def initialize(page)
+        def initialize(page, context:)
           super()
           @page = page
+          @context = context
         end
 
         def close
-          page.context.dispose if page.use_proxy?
+          @context.dispose if page.use_proxy?
           page.close
         end
 

--- a/vessel.gemspec
+++ b/vessel.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.7.0"
 
-  s.add_runtime_dependency "ferrum", "~> 0.12"
+  s.add_runtime_dependency "ferrum", ">= 0.15"
   s.add_runtime_dependency "mechanize", ">= 2.8.5"
   s.add_runtime_dependency "nokogiri", "~> 1.13"
   s.add_runtime_dependency "thor", "~> 1.2"


### PR DESCRIPTION
When using a proxy with ferrum v0.15, I get the following error

```
lib/vessel/driver/ferrum/page.rb:20:in `close': undefined method `context' for an instance of Ferrum::Page (NoMethodError)

          page.context.dispose if page.use_proxy?
              ^^^^^^^^
```

This is probably because `Ferrum::Page#context` was removed in ferrum v0.15.

See also: https://github.com/rubycdp/ferrum/pull/431
